### PR TITLE
update github action

### DIFF
--- a/.github/workflows/update-akkasls.yml
+++ b/.github/workflows/update-akkasls.yml
@@ -32,7 +32,7 @@ jobs:
       run: python3 -m pip install requests && ./scripts/script.py
       if: steps.check.outputs.result == 'build'
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v4
       if: steps.check.outputs.result == 'build'
       with:
         title: Update akkasls version


### PR DESCRIPTION
Upgrading github action peter-evans/create-pull-request as the previous version used a deprecated node12 version

https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md


References #52 